### PR TITLE
Adds Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,22 @@
+import * as L from "leaflet";
+
+declare module "leaflet" {
+  function river(latLngs: L.LatLngExpression[], options: RiverOptions): River;
+
+  interface RiverOptions extends L.PathOptions {
+    minWidth?: number;
+    maxWidth?: number;
+    ratio?: number | null;
+  }
+
+  class River extends L.FeatureGroup {
+    constructor(layers?: L.Layer[], options?: L.LayerOptions);
+    setStyle(style: any): void;
+    setMinWidth(width: number): void;
+    setMaxWidth(width: number): void;
+    getMinWidth(): number;
+    getMaxWidth(): number;
+    useLength(ratio: number): this;
+    convertToPolyline(options: L.PolylineOptions): L.Polyline;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "drawing"
   ],
   "main": "index.js",
+  "types": "index.d.ts",
   "author": "Grigory Golikov gr.golikov@gmail.com",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR adds Typescript definitions for Leaflet.River.

Following repo is a sample of using this PR with CRA and react-leaflet.
https://github.com/two-pack/sample-leaflet-river-with-typescript